### PR TITLE
Add TypeScript type information

### DIFF
--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -1,0 +1,15 @@
+/**
+ * idx is a utility function for traversing properties on objects and arrays.
+ * If an intermediate property is either null or undefined, it is instead returned.
+ * The purpose of this function is to simplify extracting properties from
+ *  a chain of maybe-typed properties.
+ *
+ * @param source Source object
+ * @param predicate Predicate function traversing the source object returning a result
+ */
+export function idxMacro<TResult = any, TSource = any>(
+  source: TSource,
+  predicate: (source: TSource) => TResult
+): TResult;
+
+export default idxMacro;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,15 @@
+/**
+ * idx is a utility function for traversing properties on objects and arrays.
+ * If an intermediate property is either null or undefined, it is instead returned.
+ * The purpose of this function is to simplify extracting properties from
+ *  a chain of maybe-typed properties.
+ *
+ * @param source Source object
+ * @param predicate Predicate function traversing the source object returning a result
+ */
+export function idxMacro<TResult = any, TSource = any>(
+  source: TSource,
+  predicate: (source: TSource) => TResult
+): TResult;
+
+export default idxMacro;

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   ],
   "scripts": {
     "test": "jest",
-    "build": "babel idx.macro.js -d build"
+    "build": "babel idx.macro.js -d build && cp ./index.d.ts ./build/"
   },
+  "typings": "./index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dralletje/idx.macro.git"


### PR DESCRIPTION
On build, copy type information. Did the simplest thing: copy the file.

It seemed you are checking in `build/`, so copied that pattern and also committed the index.d.ts there.

Closes #6 