### PR TITLE
Fix and upgrade babel-types dependency

### DIFF
--- a/__tests__/__snapshots__/basics.test.js.snap
+++ b/__tests__/__snapshots__/basics.test.js.snap
@@ -8,8 +8,8 @@ idx(global, _ => _.test.lol);
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import idx from '../idx.macro';
+var _ref;
 
-idx(global, _ => _.test.lol);
+(_ref = global) != null ? (_ref = _ref.test) != null ? _ref.lol : _ref : _ref;
 "
 `;

--- a/__tests__/basics.test.js
+++ b/__tests__/basics.test.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const pluginTester = require('babel-plugin-tester');
-const plugin = require('babel-plugin-macros').default;
+const plugin = require('babel-plugin-macros');
 
 pluginTester({
   plugin,

--- a/build/idx.macro.js
+++ b/build/idx.macro.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var t = require('babel-types');
+var t = require('@babel/types');
 
 var _require = require('babel-plugin-macros'),
     createMacro = _require.createMacro;

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -1,15 +1,71 @@
 /**
- * idx is a utility function for traversing properties on objects and arrays.
- * If an intermediate property is either null or undefined, it is instead returned.
- * The purpose of this function is to simplify extracting properties from
- *  a chain of maybe-typed properties.
- *
- * @param source Source object
- * @param predicate Predicate function traversing the source object returning a result
+ * DeepRequiredArray
+ * Nested array condition handler
  */
-export function idxMacro<TResult = any, TSource = any>(
-  source: TSource,
-  predicate: (source: TSource) => TResult
-): TResult;
+interface DeepRequiredArray<T> extends Array<DeepRequired<NonNullable<T>>> {}
 
-export default idxMacro;
+/**
+ * DeepRequiredObject
+ * Nested object condition handler
+ */
+type DeepRequiredObject<T> = {
+  [P in keyof T]-?: DeepRequired<NonNullable<T[P]>>
+};
+
+/**
+ * Function that has deeply required return type
+ */
+type FunctionWithRequiredReturnType<
+  T extends (...args: any[]) => any
+> = T extends (...args: infer A) => infer R
+  ? (...args: A) => DeepRequired<R>
+  : never;
+
+/**
+ * DeepRequired
+ * Required that works for deeply nested structure
+ */
+type DeepRequired<T> = T extends any[]
+  ? DeepRequiredArray<T[number]>
+  : T extends (...args: any[]) => any
+    ? FunctionWithRequiredReturnType<T>
+    : T extends object ? DeepRequiredObject<T> : T;
+
+/**
+ * Traverses properties on objects and arrays. If an intermediate property is
+ * either null or undefined, it is instead returned. The purpose of this method
+ * is to simplify extracting properties from a chain of maybe-typed properties.
+ *
+ * Consider the following type:
+ *
+ *     const props: {
+ *       user?: {
+ *         name: string,
+ *         friends?: Array<User>,
+ *       }
+ *     };
+ *
+ * Getting to the friends of my first friend would resemble:
+ *
+ *      props.user &&
+ *      props.user.friends &&
+ *      props.user.friends[0] &&
+ *      props.user.friends[0].friends
+ *
+ * Instead, `idx` allows us to safely write:
+ *
+ *      idx(props, _ => _.user.friends[0].friends)
+ *
+ * The second argument must be a function that returns one or more nested member
+ * expressions. Any other expression has undefined behavior.
+ *
+ * @param prop - Parent object
+ * @param accessor - Accessor function
+ * @return the property accessed if accessor function could reach to property,
+ * null or undefined otherwise
+ */
+declare function idx<T1, T2>(
+  prop: T1,
+  accessor: (prop: NonNullable<DeepRequired<T1>>) => T2,
+): T2 | null | undefined;
+export default idx;

--- a/idx.macro.js
+++ b/idx.macro.js
@@ -1,4 +1,4 @@
-const t = require('babel-types');
+const t = require('@babel/types');
 const { createMacro } = require('babel-plugin-macros');
 
 function checkIdxArguments(file, node) {
@@ -6,34 +6,34 @@ function checkIdxArguments(file, node) {
   if (args.length !== 2) {
     throw file.buildCodeFrameError(
       node,
-      'The `idx` function takes exactly two arguments.',
+      'The `idx` function takes exactly two arguments.'
     );
   }
   const arrowFunction = args[1];
   if (!t.isArrowFunctionExpression(arrowFunction)) {
     throw file.buildCodeFrameError(
       arrowFunction,
-      'The second argument supplied to `idx` must be an arrow function.',
+      'The second argument supplied to `idx` must be an arrow function.'
     );
   }
   if (!t.isExpression(arrowFunction.body)) {
     throw file.buildCodeFrameError(
       arrowFunction.body,
       'The body of the arrow function supplied to `idx` must be a single ' +
-      'expression (without curly braces).',
+        'expression (without curly braces).'
     );
   }
   if (arrowFunction.params.length !== 1) {
     throw file.buildCodeFrameError(
       arrowFunction.params[2] || arrowFunction,
-      'The arrow function supplied to `idx` must take exactly one parameter.',
+      'The arrow function supplied to `idx` must take exactly one parameter.'
     );
   }
   const input = arrowFunction.params[0];
   if (!t.isIdentifier(input)) {
     throw file.buildCodeFrameError(
       arrowFunction.params[0],
-      'The parameter supplied to `idx` must be an identifier.',
+      'The parameter supplied to `idx` must be an identifier.'
     );
   }
 }
@@ -44,10 +44,10 @@ function makeCondition(node, state, inside) {
       t.BinaryExpression(
         '!=',
         t.AssignmentExpression('=', state.temp, node),
-        t.NullLiteral(),
+        t.NullLiteral()
       ),
       inside,
-      state.temp,
+      state.temp
     );
   } else {
     return node;
@@ -59,11 +59,7 @@ function makeChain(node, state, inside) {
     return makeChain(
       node.callee,
       state,
-      makeCondition(
-        t.CallExpression(state.temp, node.arguments),
-        state,
-        inside,
-      ),
+      makeCondition(t.CallExpression(state.temp, node.arguments), state, inside)
     );
   } else if (t.isMemberExpression(node)) {
     return makeChain(
@@ -72,22 +68,22 @@ function makeChain(node, state, inside) {
       makeCondition(
         t.MemberExpression(state.temp, node.property, node.computed),
         state,
-        inside,
-      ),
+        inside
+      )
     );
   } else if (t.isIdentifier(node)) {
     if (node.name !== state.base.name) {
       throw state.file.buildCodeFrameError(
         node,
         'The parameter of the arrow function supplied to `idx` must match ' +
-        'the base of the body expression.',
+          'the base of the body expression.'
       );
     }
     return makeCondition(state.input, state, inside);
   } else {
     throw state.file.buildCodeFrameError(
       node,
-      'The `idx` body can only be composed of properties and methods.',
+      'The `idx` body can only be composed of properties and methods.'
     );
   }
 }
@@ -97,26 +93,24 @@ const idx_transform = (path, state) => {
   const node = path.node;
   checkIdxArguments(state.file, node);
   const temp = path.scope.generateUidIdentifier('ref');
-  const replacement = makeChain(
-    node.arguments[1].body,
-    {
-      file: state.file,
-      input: node.arguments[0],
-      base: node.arguments[1].params[0],
-      temp,
-    },
-  );
+  const replacement = makeChain(node.arguments[1].body, {
+    file: state.file,
+    input: node.arguments[0],
+    base: node.arguments[1].params[0],
+    temp,
+  });
   path.replaceWith(replacement);
-  path.scope.push({id: temp});
-}
+  path.scope.push({ id: temp });
+};
 
 module.exports = createMacro(({ state, references }) => {
   references.default.forEach(referencePath => {
     if (referencePath.parentPath.type === 'CallExpression') {
       idx_transform(referencePath.parentPath, state);
+    } else {
+      throw Error(
+        `idx.macro can only be used a function, and can not be passed around as an argument.`
+      );
     }
-    else {
-      throw Error(`idx.macro can only be used a function, and can not be passed around as an argument.`);
-    }
-  })
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,28 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.11",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
+      }
+    },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -1361,8 +1383,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "exec-sh": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/dralletje/idx.macro#readme",
   "dependencies": {
+    "@babel/types": "^7.4.0",
     "babel-plugin-macros": "^2.4.2"
   },
   "babel": {


### PR DESCRIPTION
This macro is currently using the `babel-types` package but it currently isn't listed as a dependency and can lead to problems for consumers.

I've added the `@babel/types` as a dependency and swapped usage from `babel-types` to `@babel/types`.

I also took the liberty to fix the one test from failing to run and updated the snapshot. I also updated the built files.